### PR TITLE
(fix) Use isEqual comparison for isNewOptionSelected in Creatable.

### DIFF
--- a/packages/react-select/src/Creatable.js
+++ b/packages/react-select/src/Creatable.js
@@ -12,6 +12,7 @@ import Select, { type Props as SelectProps } from './Select';
 import type { OptionType, OptionsType, ValueType, ActionMeta } from './types';
 import { cleanValue } from './utils';
 import manageState from './stateManager';
+import isEqual from './internal/react-fast-compare';
 
 export type DefaultCreatableProps = {|
   /* Allow options to be created while the `isLoading` prop is true. Useful to
@@ -144,8 +145,12 @@ export const makeCreatableSelect = <C: {}>(
       }
       const { newOption } = this.state;
       const valueArray = Array.isArray(newValue) ? newValue : [newValue];
+      const isNewOptionSelected = isEqual(
+        valueArray[valueArray.length - 1],
+        newOption
+      );
 
-      if (valueArray[valueArray.length - 1] === newOption) {
+      if (isNewOptionSelected) {
         if (onCreateOption) onCreateOption(inputValue);
         else {
           const newOptionData = getNewOptionData(inputValue, inputValue);


### PR DESCRIPTION
Diandra and I have recently been experiencing weirdness with onCreateOption in react-select. This is prop you use when you want to create a new contact from the dropdown, rather than select an existing one. See the Loom here: https://www.loom.com/share/032f5cd3b0ea421398ce6e3d4aa9781b.

This is an open bug in `react-select` on 3.1.0, the version we’re running. This [pull request copies an open pull request which fixes this issue on the main project](https://github.com/JedWatson/react-select/pull/3990). 

The main project pull request has not received attention from the maintainer, so we made the decision to fork the project and fix it ourselves to unblock PCM.

Created this ticket to track follow up: https://warrenpay.atlassian.net/browse/FRON-2101.

I've set a reminder for myself to check the project every two weeks for updates.